### PR TITLE
Возможность сменить пины Serial для ESP8266/32

### DIFF
--- a/src/GyverBME280.cpp
+++ b/src/GyverBME280.cpp
@@ -18,10 +18,15 @@ bool GyverBME280::begin(void) {
     return begin(0x76);
 }
 
-bool GyverBME280::begin(uint8_t address) {	
+bool GyverBME280::begin(uint8_t address, int __attribute__((unused)) sda, int __attribute__((unused)) scl) {	
     _i2c_address = address;
     /* === Start I2C bus & check BME280 === */
-    Wire.begin();                             		// Start I2C bus 
+#if defined(ESP32) || defined (ESP8266)
+            if (sda || scl) Wire.begin(sda, scl);   // Start I2C bus with custom pins
+            else Wire.begin();
+#else
+            Wire.begin();                           // Start I2C bus 
+#endif
     if (!reset()) return false;                     // BME280 software reset & ack check
     uint8_t ID = readRegister(0xD0);
     if (ID != 0x60 && ID != 0x58) return false;	    // Check chip ID (bme/bmp280)

--- a/src/GyverBME280.h
+++ b/src/GyverBME280.h
@@ -52,7 +52,11 @@ class GyverBME280 {
 public:
     GyverBME280();								// Create an object of class BME280
     bool begin(void);							// Initialize sensor with standart 0x76 address	
-    bool begin(uint8_t address);				// Initialize sensor with not standart 0x76 address	
+    bool begin(                                 // Initialize sensor with not standart 0x76 address	
+        uint8_t address, 
+        int __attribute__((unused)) sda = 0, 
+        int __attribute__((unused)) scl = 0
+    );	
     bool isMeasuring(void);						// Returns 'true' while the measurement is in progress					
     float readPressure(void);					// Read and calculate atmospheric pressure [float , Pa]
     float readHumidity(void);					// Read and calculate air humidity [float , %]


### PR DESCRIPTION
Расширил параметры ф-ии begin необязательными sda, scl.
Появилась возможность указать конкретные пины при открытии Serial для ESP платформ.