### PR TITLE
Converted begin() to pass in Wire object, clarified names

### DIFF
--- a/src/GyverBME280.cpp
+++ b/src/GyverBME280.cpp
@@ -4,8 +4,9 @@
 
 float pressureToAltitude(float pressure) {
     if (!pressure) return 0;                                   // If the pressure module has been disabled return '0'
-    pressure /= 100.0F;                                        // Convert [Pa] to [hPa]
-    return 44330.0 * (1.0 - pow(pressure / 1013.25, 0.1903));  // Сalculate altitude
+    // "sea-level" pressure in Pa (within 10% of 101325)
+    // https://en.wikipedia.org/wiki/Atmospheric_pressure#Mean_sea-level_pressure
+    return (float)44330.77 * ((float)1.0 - pow((float)pressure / (float)REF_PRESSURE, 0.190263));  // Сalculate altitude
 }
 
 float pressureToMmHg(float pressure) {
@@ -14,55 +15,55 @@ float pressureToMmHg(float pressure) {
 
 /* ============ Setup & begin ============ */
 
-bool GyverBME280::begin(void) {
-    return begin(0x76);
+bool GyverBME280::begin(TwoWire &wirePort) {
+    return begin(_i2c_address,wirePort);
 }
 
-bool GyverBME280::begin(uint8_t address) {
+bool GyverBME280::begin(uint8_t address, TwoWire &wirePort) {
     _i2c_address = address;
-    /* === Start I2C bus & check BME280 === */
-    Wire.begin();                // Start I2C bus
+    // We use an I2C Wire bus already created.
+    _wire = &wirePort;
     if (!reset()) return false;  // BME280 software reset & ack check
-    uint8_t ID = readRegister(0xD0);
+    uint8_t ID = readRegister(BME280_CHIPID);
     if (ID != 0x60 && ID != 0x58) return false;  // Check chip ID (bme/bmp280)
     readCalibrationData();                       // Read all calibration values
 
     /* === Load settings to BME280 === */
-    writeRegister(0xF2, _hum_oversampl);                                                        // write hum oversampling value
-    writeRegister(0xF2, readRegister(0xF2));                                                    // rewrite hum oversampling register
-    writeRegister(0xF4, ((_temp_oversampl << 5) | (_press_oversampl << 2) | _operating_mode));  // write temp & press oversampling value , normal mode
-    writeRegister(0xF5, ((_standby_time << 5) | (_filter_coef << 2)));                          // write standby time & filter coef
+    writeRegister(BME280_CONTROLHUMID, _hum_oversampl);                                                        // write hum oversampling value
+    writeRegister(BME280_CONTROLHUMID, readRegister(BME280_CONTROLHUMID));                                                    // rewrite hum oversampling register
+    writeRegister(BME280_CONTROL, ((_temp_oversampl << 5) | (_press_oversampl << 2) | _operating_mode));  // write temp & press oversampling value , normal mode
+    writeRegister(BME280_CONFIG, ((_standby_time << 5) | (_filter_coef << 2)));                          // write standby time & filter coef
     return true;
 }
 
-void GyverBME280::setMode(uint8_t mode) {
-    _operating_mode = mode;
+void GyverBME280::setMode(uint8_t value) {
+    _operating_mode = value;
 }
 
-void GyverBME280::setFilter(uint8_t mode) {
-    _filter_coef = mode;
+void GyverBME280::setFilter(uint8_t value) {
+    _filter_coef = value;
 }
 
-void GyverBME280::setStandbyTime(uint8_t mode) {
-    _standby_time = mode;
+void GyverBME280::setStandbyTime(uint8_t value) {
+    _standby_time = value;
 }
 
-void GyverBME280::setHumOversampling(uint8_t mode) {
-    _hum_oversampl = mode;
+void GyverBME280::setHumOversampling(uint8_t value) {
+    _hum_oversampl = value;
 }
 
-void GyverBME280::setTempOversampling(uint8_t mode) {
-    _temp_oversampl = mode;
+void GyverBME280::setTempOversampling(uint8_t value) {
+    _temp_oversampl = value;
 }
 
-void GyverBME280::setPressOversampling(uint8_t mode) {
-    _press_oversampl = mode;
+void GyverBME280::setPressOversampling(uint8_t value) {
+    _press_oversampl = value;
 }
 
 /* ============ Reading ============ */
 
 int32_t GyverBME280::readTempInt(void) {
-    int32_t temp_raw = readRegister24(0xFA);  // Read 24-bit value
+    int32_t temp_raw = readRegister24(BME280_TEMPDATA);  // Read 24-bit value
     if (temp_raw == 0x800000) return 0;       // If the temperature module has been disabled return '0'
 
     temp_raw >>= 4;  // Start temperature reading in integers
@@ -78,7 +79,7 @@ float GyverBME280::readTemperature(void) {
 }
 
 float GyverBME280::readPressure(void) {
-    uint32_t press_raw = readRegister24(0xF7);  // Read 24-bit value
+    uint32_t press_raw = readRegister24(BME280_PRESSUREDATA);  // Read 24-bit value
     if (press_raw == 0x800000) return 0;        // If the pressure module has been disabled return '0'
 
     press_raw >>= 4;  // Start pressure converting
@@ -101,11 +102,11 @@ float GyverBME280::readPressure(void) {
 }
 
 float GyverBME280::readHumidity(void) {
-    Wire.beginTransmission(_i2c_address);  // Start I2C transmission
-    Wire.write(0xFD);                      // Request humidity data register
-    if (Wire.endTransmission() != 0) return 0;
-    Wire.requestFrom(_i2c_address, 2);                                       // Request humidity data
-    int32_t hum_raw = ((uint16_t)Wire.read() << 8) | (uint16_t)Wire.read();  // Read humidity data
+    _wire->beginTransmission(_i2c_address);  // Start I2C transmission
+    _wire->write(BME280_HUMIDDATA);          // Request humidity data register
+    if (_wire->endTransmission() != 0) return 0;
+    _wire->requestFrom(_i2c_address, 2);                                       // Request humidity data
+    int32_t hum_raw = ((uint16_t)_wire->read() << 8) | (uint16_t)_wire->read();  // Read humidity data
     if (hum_raw == 0x8000) return 0;                                         // If the humidity module has been disabled return '0'
 
     int32_t value = (readTempInt() - ((int32_t)76800));  // Start humidity converting
@@ -121,11 +122,18 @@ float GyverBME280::readHumidity(void) {
 /* ============ Misc ============ */
 
 bool GyverBME280::isMeasuring(void) {
-    return (bool)((readRegister(0xF3) & 0x08) >> 3);  // Read status register & mask bit "measuring"
+    return (bool)((readRegister(BME280_STATUS) & 0x08) >> 3);  // Read status register & mask bit "measuring"
 }
 
 void GyverBME280::oneMeasurement(void) {
-    writeRegister(0xF4, ((readRegister(0xF4) & 0xFC) | 0x02));  // Set the operating mode to FORCED_MODE
+    writeRegister(BME280_CONTROL, ((readRegister(BME280_CONTROL) & 0xFC) | FORCED_MODE));  // Set the operating mode to FORCED_MODE
+}
+
+void GyverBME280::triggerMeasurement(void) {
+    oneMeasurement();
+    // wait for it to complete
+    while( isMeasuring() == false); // Wait for sensor to start measurment
+    while( isMeasuring() == true); // Hang out while sensor completes the reading    
 }
 
 GyverBME280::GyverBME280() {}
@@ -134,71 +142,71 @@ GyverBME280::GyverBME280() {}
 
 /* = BME280 software reset = */
 bool GyverBME280::reset(void) {
-    if (!writeRegister(0xE0, 0xB6)) return false;
+    if (!writeRegister(BME280_SOFTRESET, 0xB6)) return false;
     delay(10);
     return true;
 }
 
 /* = Read and combine three BME280 registers = */
 uint32_t GyverBME280::readRegister24(uint8_t address) {
-    Wire.beginTransmission(_i2c_address);
-    Wire.write(address);
-    if (Wire.endTransmission() != 0) return 0x800000;
-    Wire.requestFrom(_i2c_address, 3);
-    return (((uint32_t)Wire.read() << 16) | ((uint32_t)Wire.read() << 8) | (uint32_t)Wire.read());
+    _wire->beginTransmission(_i2c_address);
+    _wire->write(address);
+    if (_wire->endTransmission() != 0) return 0x800000;
+    _wire->requestFrom(_i2c_address, 3);
+    return (((uint32_t)_wire->read() << 16) | ((uint32_t)_wire->read() << 8) | (uint32_t)_wire->read());
 }
 
 /* = Write one 8-bit BME280 register = */
 bool GyverBME280::writeRegister(uint8_t address, uint8_t data) {
-    Wire.beginTransmission(_i2c_address);
-    Wire.write(address);
-    Wire.write(data);
-    if (Wire.endTransmission() != 0) return false;
+    _wire->beginTransmission(_i2c_address);
+    _wire->write(address);
+    _wire->write(data);
+    if (_wire->endTransmission() != 0) return false;
     return true;
 }
 
 /* = Read one 8-bit BME280 register = */
 uint8_t GyverBME280::readRegister(uint8_t address) {
-    Wire.beginTransmission(_i2c_address);
-    Wire.write(address);
-    if (Wire.endTransmission() != 0) return 0;
-    Wire.requestFrom(_i2c_address, 1);
-    return Wire.read();
+    _wire->beginTransmission(_i2c_address);
+    _wire->write(address);
+    if (_wire->endTransmission() != 0) return 0;
+    _wire->requestFrom(_i2c_address, 1);
+    return _wire->read();
 }
 
 /* = Structure to store all calibration values = */
 void GyverBME280::readCalibrationData(void) {
     /* first part request*/
-    Wire.beginTransmission(_i2c_address);
-    Wire.write(0x88);
-    if (Wire.endTransmission() != 0) return;
-    Wire.requestFrom(_i2c_address, 25);
+    _wire->beginTransmission(_i2c_address);
+    _wire->write(BME280_CALIB_DATA1);
+    if (_wire->endTransmission() != 0) return;
+    _wire->requestFrom(_i2c_address, 25);
     /* reading */
-    CalibrationData._T1 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._T2 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._T3 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._P1 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._P2 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._P3 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._P4 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._P5 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._P6 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._P7 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._P8 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._P9 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._H1 = Wire.read();
+    CalibrationData._T1 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._T2 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._T3 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._P1 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._P2 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._P3 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._P4 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._P5 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._P6 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._P7 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._P8 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._P9 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._H1 = _wire->read();
 
     /* second part request*/
-    Wire.beginTransmission(_i2c_address);
-    Wire.write(0xE1);
-    Wire.endTransmission();
-    Wire.requestFrom(_i2c_address, 8);
+    _wire->beginTransmission(_i2c_address);
+    _wire->write(BME280_CALIB_DATA2);
+    _wire->endTransmission();
+    _wire->requestFrom(_i2c_address, 8);
     /* reading */
-    CalibrationData._H2 = (Wire.read() | (Wire.read() << 8));
-    CalibrationData._H3 = Wire.read();
-    CalibrationData._H4 = (Wire.read() << 4);
-    uint8_t interVal = Wire.read();
+    CalibrationData._H2 = (_wire->read() | (_wire->read() << 8));
+    CalibrationData._H3 = _wire->read();
+    CalibrationData._H4 = (_wire->read() << 4);
+    uint8_t interVal = _wire->read();
     CalibrationData._H4 |= (interVal & 0xF);
-    CalibrationData._H5 = (((interVal & 0xF0) >> 4) | (Wire.read() << 4));
-    CalibrationData._H6 = Wire.read();
+    CalibrationData._H5 = (((interVal & 0xF0) >> 4) | (_wire->read() << 4));
+    CalibrationData._H6 = _wire->read();
 }

--- a/src/GyverBME280.h
+++ b/src/GyverBME280.h
@@ -44,13 +44,32 @@
 #define FILTER_COEF_8 0x03
 #define FILTER_COEF_16 0x04
 
+// calibration block T1..T3, P1..P9, H1
+#define BME280_CALIB_DATA1 0x88
+// calibration block H2..H6
+#define BME280_CALIB_DATA2 0xE1
+// actual sensor data
+#define BME280_CONTROLHUMID 0xF2
+#define BME280_STATUS 0xF3
+#define BME280_CONTROL 0xF4
+#define BME280_CONFIG 0xF5
+#define BME280_PRESSUREDATA 0xF7
+#define BME280_TEMPDATA 0xFA
+#define BME280_HUMIDDATA 0xFD
+// module info
+#define BME280_CHIPID 0xD0
+#define BME280_VERSION 0xD1
+// reset control
+#define BME280_SOFTRESET 0xE0
+
+#define REF_PRESSURE 101325
 // ================================= CLASS ===================================
 
 class GyverBME280 {
    public:
     GyverBME280();                // Create an object of class BME280
-    bool begin(void);             // Initialize sensor with standart 0x76 address
-    bool begin(uint8_t address);  // Initialize sensor with not standart 0x76 address
+    bool begin(TwoWire &wirePort = Wire);             // Initialize sensor with standart 0x76 address
+    bool begin(uint8_t address, TwoWire &wirePort);  // Initialize sensor with custom address and optionally wire lines
     bool isMeasuring(void);       // Returns 'true' while the measurement is in progress
     float readPressure(void);     // Read and calculate atmospheric pressure [float , Pa]
     float readHumidity(void);     // Read and calculate air humidity [float , %]
@@ -66,6 +85,7 @@ class GyverBME280 {
    private:
     //============================== DEFAULT SETTINGS ========================================|
     int _i2c_address = 0x76;                    // BME280 address on I2C bus                  |
+    TwoWire *_wire = 0;                         // Default to Wire port
     uint8_t _operating_mode = NORMAL_MODE;      // Sensor operation mode                      |
     uint8_t _standby_time = STANDBY_250MS;      // Time between measurements in NORMAL_MODE      |
     uint8_t _filter_coef = FILTER_COEF_16;      // Filter ratio IIR                           |


### PR DESCRIPTION
Вы можете вызвать Wire.begin(8,9) вне библиотеки, а затем просто передать ей объект, например,

Wire.begin(8,9); 
bme.begin(Wire); 

Я также прояснил некоторые названия для различных регистров. Надеюсь, это добавит ценности вашей прекрасной библиотеке.